### PR TITLE
refactor: adjust `--cores` settings for profiles

### DIFF
--- a/env/environment.yml
+++ b/env/environment.yml
@@ -20,7 +20,7 @@ channels:
 
 dependencies:
   - bash=5.0.018
-  - snakemake=6.9.1
+  - snakemake=7.18.2
   - unzip=6.0
   - python=3.9.4
   - pandas=1.2.4

--- a/execution/run.sh
+++ b/execution/run.sh
@@ -202,7 +202,7 @@ fi
 
 # check for overwriting the default number of cores
 if [ -z "$CORES" ]; then
-    CORES=1
+    CORES="all"
 fi
 
 # if this is not a graph run - check other parameters

--- a/profiles/sge-conda/config.yaml
+++ b/profiles/sge-conda/config.yaml
@@ -9,3 +9,4 @@ jobscript: sge-jobscript.sh
 cluster: "sge-submit.py"
 cluster-status: "sge-status.py"
 latency-wait: 120
+jobs: 4096

--- a/profiles/sge-conda/config.yaml
+++ b/profiles/sge-conda/config.yaml
@@ -1,6 +1,5 @@
 snakefile: "../Snakefile"
 local-cores: 1
-cores: 1
 printshellcmds: true
 rerun-incomplete: true
 use-conda: true
@@ -10,4 +9,3 @@ jobscript: sge-jobscript.sh
 cluster: "sge-submit.py"
 cluster-status: "sge-status.py"
 latency-wait: 120
-jobs: 256

--- a/profiles/sge-singularity/config.yaml
+++ b/profiles/sge-singularity/config.yaml
@@ -1,6 +1,5 @@
 snakefile: "../Snakefile"
 local-cores: 1
-cores: 1
 printshellcmds: true
 rerun-incomplete: true
 use-singularity: true
@@ -9,4 +8,3 @@ jobscript: sge-jobscript.sh
 cluster: "sge-submit.py"
 cluster-status: "sge-status.py"
 latency-wait: 120
-jobs: 256

--- a/profiles/sge-singularity/config.yaml
+++ b/profiles/sge-singularity/config.yaml
@@ -8,3 +8,4 @@ jobscript: sge-jobscript.sh
 cluster: "sge-submit.py"
 cluster-status: "sge-status.py"
 latency-wait: 120
+jobs: 4096

--- a/profiles/slurm-conda/config.yaml
+++ b/profiles/slurm-conda/config.yaml
@@ -1,6 +1,5 @@
 snakefile: "../Snakefile"
 local-cores: 1
-cores: 1
 printshellcmds: true
 rerun-incomplete: true
 use-conda: true
@@ -10,4 +9,3 @@ jobscript: "slurm-jobscript.sh"
 cluster: "slurm-submit.py"
 cluster-status: "slurm-status.py"
 latency-wait: 120
-jobs: 256

--- a/profiles/slurm-conda/config.yaml
+++ b/profiles/slurm-conda/config.yaml
@@ -9,3 +9,4 @@ jobscript: "slurm-jobscript.sh"
 cluster: "slurm-submit.py"
 cluster-status: "slurm-status.py"
 latency-wait: 120
+jobs: 4096

--- a/profiles/slurm-singularity/config.yaml
+++ b/profiles/slurm-singularity/config.yaml
@@ -8,3 +8,4 @@ jobscript: "slurm-jobscript.sh"
 cluster: "slurm-submit.py"
 cluster-status: "slurm-status.py"
 latency-wait: 120
+jobs: 4096

--- a/profiles/slurm-singularity/config.yaml
+++ b/profiles/slurm-singularity/config.yaml
@@ -1,6 +1,5 @@
 snakefile: "../Snakefile"
 local-cores: 1
-cores: 1
 printshellcmds: true
 rerun-incomplete: true
 use-singularity: true
@@ -9,4 +8,3 @@ jobscript: "slurm-jobscript.sh"
 cluster: "slurm-submit.py"
 cluster-status: "slurm-status.py"
 latency-wait: 120
-jobs: 256


### PR DESCRIPTION
## Description

Adjusted the execution script and _snakemake_ profiles to the following settings:  

- no changes for the local execution, all was fine there
- if `CORES` is provided from the command line it overrides `--cores` parameter for the profile; in case of cluster execution it limits the resources `snakemake` will use on the cluster (even though it reserves more, as you checked); therefore it makes sense to skip this flag for cluster execution because:
- the default values for `CORES` is now `all`, and it also gets passed to `snakemake` argument `--cores`; in such case the process will use as many CPUs as requested.
- the settings above make sense in case of local execution, though, where the resources should be limmitted from the command line
- `jobs` param removed completely from the profiles, not necessary

See more info from the docs:

<img width="729" alt="Screenshot 2022-12-11 at 22 59 34" src="https://user-images.githubusercontent.com/19755308/206934697-16c60141-b862-4b80-968e-2279aa722c84.png">

@ajgruber : please take a look at this before our next meeting, if everything is as you wished I will merge this on Tuesday.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation updated
- [x] Codebase refactoring

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
